### PR TITLE
Fix: Prevent null reference when measurement location is unloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.9.9] - 2025-10-15
+### Fixed
+- Fixed null reference exception when measurement location chunk is not loaded
+- Added validation to check if measurement position is accessible before taking temperature readings
+
+### Added
+- Intelligent measurement failure handling with consecutive failure counter
+- Admin notifications when sensor location is unreachable (after 5 failed attempts)
+- Enhanced `/tempsensor` command with measurement status display:
+  - Current status (Active ✓ / Warning ⚠)
+  - Time since last successful measurement
+  - Count of consecutive failed attempts
+- Automatic retry mechanism for temperature measurements
+
+### Improved
+- Better error logging for debugging measurement issues
+- More informative feedback when sensor location is not loaded
+
 ## [0.9.8] - 2025-03-24
 ### Changed
 - Temperature history tree view now defaults to collapsed state for all years/months except current ones

--- a/TemperatureMonitor.csproj
+++ b/TemperatureMonitor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/assets/temperaturemonitor/lang/en.json
+++ b/assets/temperaturemonitor/lang/en.json
@@ -33,5 +33,19 @@
     "sensor_admin_note": " (Only server administrators can change this location.)",
     "font_size": "Font size",
     "greenhouse_mode": "Greenhouse mode (+5°C)",
-    "greenhouse_tooltip": "Shows temperatures adjusted for greenhouse effect (+5°C)"
+    "greenhouse_tooltip": "Shows temperatures adjusted for greenhouse effect (+5°C)",
+    "sensor_status_active": "Active [OK]",
+    "sensor_status_warning": "Warning [!] - Location not loaded",
+    "sensor_last_measurement": "Last successful measurement: {0}",
+    "sensor_failed_attempts": "Consecutive failed attempts: {0}",
+    "sensor_never_measured": "No measurements taken yet",
+    "sensor_location_unreachable": "[!] Warning: Temperature sensor location is not loaded. Consider using '/tempsensor setcurrlocation' to move the sensor to an active area.",
+    "sensor_location_unreachable_info": "The measurement location at ({0}, {1}, {2}) is not currently loaded. Temperature monitoring is paused until the area becomes accessible.",
+    "time_just_now": "just now",
+    "time_minute_ago": "1 minute ago",
+    "time_minutes_ago": "{0} minutes ago",
+    "time_hour_ago": "1 hour ago",
+    "time_hours_ago": "{0} hours ago",
+    "time_day_ago": "1 day ago",
+    "time_days_ago": "{0} days ago"
 }

--- a/assets/temperaturemonitor/lang/pl.json
+++ b/assets/temperaturemonitor/lang/pl.json
@@ -33,5 +33,19 @@
     "sensor_admin_note": " (Tylko administratorzy serwera mogą zmienić tę lokalizację.)",
     "font_size": "Rozmiar czcionki",
     "greenhouse_mode": "Tryb szklarniowy (+5°C)",
-    "greenhouse_tooltip": "Pokazuje temperatury dostosowane do efektu szklarniowego (+5°C)"
+    "greenhouse_tooltip": "Pokazuje temperatury dostosowane do efektu szklarniowego (+5°C)",
+    "sensor_status_active": "Aktywny [OK]",
+    "sensor_status_warning": "Ostrzeżenie [!] - Lokacja nie załadowana",
+    "sensor_last_measurement": "Ostatni udany pomiar: {0}",
+    "sensor_failed_attempts": "Kolejne nieudane próby: {0}",
+    "sensor_never_measured": "Nie wykonano jeszcze żadnych pomiarów",
+    "sensor_location_unreachable": "[!] Ostrzeżenie: Lokacja czujnika temperatury nie jest załadowana. Rozważ użycie '/tempsensor setcurrlocation' aby przenieść czujnik do aktywnego obszaru.",
+    "sensor_location_unreachable_info": "Lokacja pomiaru ({0}, {1}, {2}) nie jest obecnie załadowana. Monitorowanie temperatury jest wstrzymane do czasu, aż obszar stanie się dostępny.",
+    "time_just_now": "przed chwilą",
+    "time_minutes_ago": "{0} minut temu",
+    "time_minute_ago": "minutę temu",
+    "time_hours_ago": "{0} godzin temu",
+    "time_hour_ago": "godzinę temu",
+    "time_days_ago": "{0} dni temu",
+    "time_day_ago": "dzień temu"
 }

--- a/modinfo.json
+++ b/modinfo.json
@@ -2,11 +2,11 @@
   "type": "code",
   "modid": "TemperatureMonitor",
   "name": "Temperature Monitor [BETA]",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Automatically monitors and records minimum and maximum temperatures in the game world. Data is accessible by pressing Alt+T. Useful for tracking long-term climate statistics or planning crops and buildings according to weather conditions.",
   "authors": ["Potusek"],
   "dependencies": {
-    "game": "1.20.10",
-    "vsimgui": "1.1.7"
+    "game": "1.21.5",
+    "vsimgui": "1.1.14"
   }
 }

--- a/src/Translation.cs
+++ b/src/Translation.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
-using Newtonsoft.Json;
 using Vintagestory.API.Common;
 using Vintagestory.API.Config;
 
@@ -20,22 +17,29 @@ namespace TemperatureMonitor
 
         public string Get(string key, params object[]? args)
         {
-            // Użyj wbudowanego systemu tłumaczeń
-            string translated = Lang.Get("temperaturemonitor:" + key, langCode);
+            // Użyj wbudowanego systemu tłumaczeń BEZ langCode - użyje aktualnego języka gracza
+            string translated = Lang.Get("temperaturemonitor:" + key);
             
-            // Jeśli zwrócono ten sam klucz, oznacza to, że tłumaczenie nie zostało znalezione
-            if (translated == "temperaturemonitor:" + key)
+            // Jeśli zwrócono klucz z prefiksem, oznacza to że tłumaczenie nie zostało znalezione
+            string fullKey = "temperaturemonitor:" + key;
+            if (translated == fullKey)
             {
-                api.Logger.Debug($"[TemperatureMonitor] Translation NOT found for '{key}'");
-                return key;
+                api.Logger.Warning($"[TemperatureMonitor] Translation NOT found for '{key}'");
+                return key; // Zwróć sam klucz bez prefiksu
             }
-            
-            // api.Logger.Debug($"[TemperatureMonitor] Translation found for '{key}': '{translated}'");
             
             // Jeśli mamy argumenty do formatowania
             if (args != null && args.Length > 0)
             {
-                return string.Format(translated, args);
+                try
+                {
+                    return string.Format(translated, args);
+                }
+                catch (FormatException ex)
+                {
+                    api.Logger.Error($"[TemperatureMonitor] Format error for key '{key}': {ex.Message}");
+                    return translated; // Zwróć nieformatowany tekst
+                }
             }
             
             return translated;


### PR DESCRIPTION
- Add chunk loading validation before temperature measurement
- Implement failure counter with admin notifications (threshold: 5)
- Enhance /tempsensor command with status display
- Remove EnsureMeasurementAreaIsLoaded call causing startup crash
- Fix Translation class to use Lang.Get() without langCode parameter
- Add proper error handling for string formatting
- Replace Unicode symbols with ASCII equivalents
- Add time translation variants with proper Polish declensions
- Fix UTF-8 encoding for Polish language file

Fixes issue where mod crashes when spawn point or measurement location is not loaded (e.g., player far from spawn on install).